### PR TITLE
Use exceptions for errors

### DIFF
--- a/lib/datix/date_time.ex
+++ b/lib/datix/date_time.ex
@@ -56,13 +56,8 @@ defmodule Datix.DateTime do
   """
   @spec parse(String.t(), String.t() | Datix.compiled(), list()) ::
           {:ok, DateTime.t(), {String.t(), integer()}}
-          | {:error, :invalid_date}
-          | {:error, :invalid_input}
-          | {:error, {:parse_error, expected: String.t(), got: String.t()}}
-          | {:error, {:conflict, [expected: term(), got: term(), modifier: String.t()]}}
-          | {:error, {:invalid_string, [modifier: String.t()]}}
-          | {:error, {:invalid_integer, [modifier: String.t()]}}
-          | {:error, {:invalid_modifier, [modifier: String.t()]}}
+          | {:error,
+             Datix.FormatStringError.t() | Datix.ParseError.t() | Datix.ValidationError.t()}
   def parse(datetime_str, format, opts \\ []) do
     with {:ok, data} <- Datix.strptime(datetime_str, format, opts) do
       new(data, opts)
@@ -89,18 +84,15 @@ defmodule Datix.DateTime do
   """
   @spec parse!(String.t(), String.t() | Datix.compiled(), list()) :: DateTime.t()
   def parse!(datetime_str, format, opts \\ []) do
-    datetime_str
-    |> Datix.strptime!(format, opts)
-    |> new(opts)
-    |> case do
+    case parse(datetime_str, format, opts) do
       {:ok, datetime, {"UTC", 0}} ->
         datetime
 
       {:ok, _datetime, {zone_abbr, _zone_offset}} ->
         raise ArgumentError, "parse!/3 is just defined for UTC, not for #{zone_abbr}"
 
-      {:error, reason} ->
-        raise ArgumentError, "cannot build date-time, reason: #{inspect(reason)}"
+      {:error, error} when is_exception(error) ->
+        raise error
     end
   end
 

--- a/lib/datix/format_string_error.ex
+++ b/lib/datix/format_string_error.ex
@@ -1,0 +1,19 @@
+defmodule Datix.FormatStringError do
+  @moduledoc """
+  An exception for when the format string is invalid.
+  """
+
+  @moduledoc since: "v0.3.0"
+
+  @type reason :: {:invalid_modifier, String.t()}
+
+  @type t :: %__MODULE__{reason: reason}
+
+  defexception [:reason]
+
+  @impl true
+  def message(%__MODULE__{reason: reason}) do
+    {:invalid_modifier, modifier} = reason
+    "invalid format string because of invalid modifier: #{modifier}"
+  end
+end

--- a/lib/datix/naive_date_time.ex
+++ b/lib/datix/naive_date_time.ex
@@ -56,13 +56,9 @@ defmodule Datix.NaiveDateTime do
   """
   @spec parse(String.t(), String.t() | Datix.compiled(), list()) ::
           {:ok, NaiveDateTime.t()}
-          | {:error, :invalid_date}
-          | {:error, :invalid_input}
-          | {:error, {:parse_error, expected: String.t(), got: String.t()}}
-          | {:error, {:conflict, [expected: term(), got: term(), modifier: String.t()]}}
-          | {:error, {:invalid_string, [modifier: String.t()]}}
-          | {:error, {:invalid_integer, [modifier: String.t()]}}
-          | {:error, {:invalid_modifier, [modifier: String.t()]}}
+          | {:error, Datix.ValidationError.t()}
+          | {:error, Datix.FormatStringError.t()}
+          | {:error, Datix.ParseError.t()}
   def parse(naive_datetime_str, format, opts \\ []) do
     with {:ok, data} <- Datix.strptime(naive_datetime_str, format, opts) do
       new(data, opts)
@@ -75,15 +71,9 @@ defmodule Datix.NaiveDateTime do
   """
   @spec parse!(String.t(), String.t() | Datix.compiled(), list()) :: NaiveDateTime.t()
   def parse!(naive_datetime_str, format, opts \\ []) do
-    naive_datetime_str
-    |> Datix.strptime!(format, opts)
-    |> new(opts)
-    |> case do
-      {:ok, date} ->
-        date
-
-      {:error, reason} ->
-        raise ArgumentError, "cannot build naive-date-time, reason: #{inspect(reason)}"
+    case parse(naive_datetime_str, format, opts) do
+      {:ok, naive_dt} -> naive_dt
+      {:error, error} when is_exception(error) -> raise error
     end
   end
 

--- a/lib/datix/option_error.ex
+++ b/lib/datix/option_error.ex
@@ -1,0 +1,20 @@
+defmodule Datix.OptionError do
+  @moduledoc """
+  An exception that represents an error with some options.
+  """
+  @moduledoc since: "0.3.0"
+
+  @type reason :: :missing | :unknown
+
+  @type t :: %__MODULE__{reason: reason, option: atom}
+
+  defexception [:reason, :option]
+
+  @impl true
+  def message(%__MODULE__{reason: reason, option: option}) do
+    case reason do
+      :missing -> "missing option #{inspect(option)}"
+      :unknown -> "unknown option #{inspect(option)}"
+    end
+  end
+end

--- a/lib/datix/parse_error.ex
+++ b/lib/datix/parse_error.ex
@@ -1,0 +1,37 @@
+defmodule Datix.ParseError do
+  @moduledoc """
+  An exception for when there is an error parsing a string.
+  """
+  @moduledoc since: "0.3.0"
+
+  @type reason ::
+          {:expected_exact, expected :: String.t(), got :: String.t()}
+          | {:conflict, expected :: term(), got :: term()}
+          | :invalid_input
+          | :invalid_integer
+          | :invalid_string
+
+  @type t :: %__MODULE__{reason: reason, modifier: String.t()}
+
+  defexception [:reason, :modifier]
+
+  @impl true
+  def message(%__MODULE__{reason: reason, modifier: modifier}) do
+    case reason do
+      {:expected_exact, expected, got} ->
+        "expected exact string #{inspect(expected)}, got: #{inspect(got)}"
+
+      {:conflict, expected, got} when not is_nil(modifier) ->
+        "expected #{inspect(expected)}, got #{inspect(got)} for #{modifier}"
+
+      :invalid_input ->
+        "invalid input"
+
+      :invalid_integer when not is_nil(modifier) ->
+        "invalid integer for #{modifier}"
+
+      :invalid_string when not is_nil(modifier) ->
+        "invalid string for #{modifier}"
+    end
+  end
+end

--- a/lib/datix/validation_error.ex
+++ b/lib/datix/validation_error.ex
@@ -1,0 +1,24 @@
+defmodule Datix.ValidationError do
+  @moduledoc """
+  An exception for when a date or time fails validation.
+
+  An "invalid" date or time is a date or time that gets parsed correctly,
+  but that is semantically invalid. For example, a date with a day of `99`
+  is invalid.
+  """
+  @moduledoc since: "0.3.0"
+
+  @type reason :: :invalid_date | :invalid_time
+
+  @type t :: %__MODULE__{reason: reason, module: module}
+
+  defexception [:reason, :module]
+
+  @impl true
+  def message(%__MODULE__{reason: reason, module: _module}) do
+    case reason do
+      :invalid_date -> "date is not valid"
+      :invalid_time -> "time is not valid"
+    end
+  end
+end

--- a/test/datix/date_time_test.exs
+++ b/test/datix/date_time_test.exs
@@ -3,6 +3,8 @@ defmodule Datix.DateTimeTest do
 
   import Prove
 
+  alias Datix.ValidationError
+
   doctest Datix.DateTime
 
   describe "parse/3" do
@@ -56,17 +58,13 @@ defmodule Datix.DateTimeTest do
             Calendar.ISO
 
     test "raises an error for an invalid time" do
-      msg = "cannot build date-time, reason: :invalid_time"
-
-      assert_raise ArgumentError, msg, fn ->
+      assert_raise ValidationError, "time is not valid", fn ->
         Datix.DateTime.parse!("2018/12/30 99:23:55", "%Y/%m/%d %H:%M:%S")
       end
     end
 
     test "raises an error for an invalid date" do
-      msg = "cannot build date-time, reason: :invalid_date"
-
-      assert_raise ArgumentError, msg, fn ->
+      assert_raise ValidationError, "date is not valid", fn ->
         Datix.DateTime.parse!("2018/99/30 99:23:55", "%Y/%m/%d %H:%M:%S")
       end
     end

--- a/test/datix/naive_date_time_test.exs
+++ b/test/datix/naive_date_time_test.exs
@@ -3,6 +3,8 @@ defmodule Datix.NaiveDateTimeTest do
 
   import Prove
 
+  alias Datix.ValidationError
+
   doctest Datix.NaiveDateTime
 
   describe "parse/3" do
@@ -49,17 +51,13 @@ defmodule Datix.NaiveDateTimeTest do
             Calendar.ISO
 
     test "raises an error for an invalid time" do
-      msg = "cannot build naive-date-time, reason: :invalid_time"
-
-      assert_raise ArgumentError, msg, fn ->
+      assert_raise ValidationError, "time is not valid", fn ->
         Datix.NaiveDateTime.parse!("2018/12/30 99:23:55", "%Y/%m/%d %H:%M:%S")
       end
     end
 
     test "raises an error for an invalid date" do
-      msg = "cannot build naive-date-time, reason: :invalid_date"
-
-      assert_raise ArgumentError, msg, fn ->
+      assert_raise ValidationError, "date is not valid", fn ->
         Datix.NaiveDateTime.parse!("2018/99/30 99:23:55", "%Y/%m/%d %H:%M:%S")
       end
     end

--- a/test/datix_test.exs
+++ b/test/datix_test.exs
@@ -1,6 +1,8 @@
 defmodule DatixTest do
   use ExUnit.Case
 
+  alias Datix.{OptionError, ParseError}
+
   doctest Datix
 
   describe "strptime/3" do
@@ -15,25 +17,28 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid input" do
-      assert Datix.strptime("foobar", "foo") == {:error, :invalid_input}
+      assert Datix.strptime("foobar", "foo") ==
+               {:error, %ParseError{reason: :invalid_input}}
 
       assert Datix.strptime("foo", "foobar") ==
-               {:error, {:parse_error, expected: "foobar", got: "foo"}}
+               {:error, %ParseError{reason: {:expected_exact, "foobar", "foo"}}}
     end
 
     test "returns error tuple for different string without modifiers" do
       assert Datix.strptime("foobar", "foopar") ==
-               {:error, {:parse_error, expected: "foopar", got: "foobar"}}
+               {:error, %ParseError{reason: {:expected_exact, "foopar", "foobar"}}}
     end
 
     test "returns an error tuple for an unknown option" do
-      assert Datix.strptime("", "", foo: :bar) == {:error, {:unknown, option: :foo}}
+      assert Datix.strptime("", "", foo: :bar) ==
+               {:error, %OptionError{reason: :unknown, option: :foo}}
     end
 
     # Invalid modifier
 
     test "returns error tuple for invalid modifier" do
-      assert Datix.strptime("foo", "%l") == {:error, {:invalid_modifier, [modifier: "%l"]}}
+      assert Datix.strptime("foo", "%l") ==
+               {:error, %Datix.FormatStringError{reason: {:invalid_modifier, "%l"}}}
     end
 
     # %a - Abbreviated name of day
@@ -43,7 +48,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %a" do
-      assert Datix.strptime("Xan", "%a") == {:error, {:invalid_string, [modifier: "%a"]}}
+      assert Datix.strptime("Xan", "%a") ==
+               {:error, %ParseError{reason: :invalid_string, modifier: "%a"}}
     end
 
     test "parses with format-string '%06a'" do
@@ -51,7 +57,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %06a" do
-      assert Datix.strptime("000foo", "%06a") == {:error, {:invalid_string, [modifier: "%06a"]}}
+      assert Datix.strptime("000foo", "%06a") ==
+               {:error, %ParseError{reason: :invalid_string, modifier: "%06a"}}
     end
 
     # %A - Full name of day
@@ -61,7 +68,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %A" do
-      assert Datix.strptime("Xan", "%A") == {:error, {:invalid_string, [modifier: "%A"]}}
+      assert Datix.strptime("Xan", "%A") ==
+               {:error, %ParseError{reason: :invalid_string, modifier: "%A"}}
     end
 
     # %b - Abbreviated month name
@@ -71,7 +79,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %b" do
-      assert Datix.strptime("Xan", "%b") == {:error, {:invalid_string, [modifier: "%b"]}}
+      assert Datix.strptime("Xan", "%b") ==
+               {:error, %ParseError{reason: :invalid_string, modifier: "%b"}}
     end
 
     # %B - Full month name
@@ -81,7 +90,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %B" do
-      assert Datix.strptime("Xan", "%B") == {:error, {:invalid_string, [modifier: "%B"]}}
+      assert Datix.strptime("Xan", "%B") ==
+               {:error, %ParseError{reason: :invalid_string, modifier: "%B"}}
     end
 
     # %c - Preferred date+time representation
@@ -97,7 +107,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %c" do
-      assert Datix.strptime("2020-foo", "%c") == {:error, {:invalid_integer, [modifier: "%m"]}}
+      assert Datix.strptime("2020-foo", "%c") ==
+               {:error, %ParseError{reason: :invalid_integer, modifier: "%m"}}
     end
 
     # %d - Day of the month
@@ -107,7 +118,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %d" do
-      assert Datix.strptime("2foo", "%d") == {:error, {:invalid_integer, [modifier: "%d"]}}
+      assert Datix.strptime("2foo", "%d") ==
+               {:error, %ParseError{reason: :invalid_integer, modifier: "%d"}}
     end
 
     # %f - Microseconds
@@ -121,7 +133,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %f" do
-      assert Datix.strptime("xy", "x%fy") == {:error, {:invalid_integer, [modifier: "%f"]}}
+      assert Datix.strptime("xy", "x%fy") ==
+               {:error, %ParseError{reason: :invalid_integer, modifier: "%f"}}
     end
 
     # %H - Hour using a 24-hour clock
@@ -131,11 +144,13 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %H" do
-      assert Datix.strptime("4", "%H") == {:error, {:invalid_integer, [modifier: "%H"]}}
+      assert Datix.strptime("4", "%H") ==
+               {:error, %ParseError{reason: :invalid_integer, modifier: "%H"}}
     end
 
     test "returns error tuple for negative value for modifier %H" do
-      assert Datix.strptime("-14", "%H") == {:error, {:invalid_integer, [modifier: "%H"]}}
+      assert Datix.strptime("-14", "%H") ==
+               {:error, %ParseError{reason: :invalid_integer, modifier: "%H"}}
     end
 
     # %I - Hour using a 12-hour clock
@@ -181,7 +196,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %q" do
-      assert Datix.strptime("-", "%q") == {:error, {:invalid_integer, [modifier: "%q"]}}
+      assert Datix.strptime("-", "%q") ==
+               {:error, %ParseError{reason: :invalid_integer, modifier: "%q"}}
     end
 
     test "parses with format-string '%03q'" do
@@ -199,7 +215,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %S" do
-      assert Datix.strptime("9-", "%S") == {:error, {:invalid_integer, [modifier: "%S"]}}
+      assert Datix.strptime("9-", "%S") ==
+               {:error, %ParseError{reason: :invalid_integer, modifier: "%S"}}
     end
 
     # %u - Day of the week
@@ -242,7 +259,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %y" do
-      assert Datix.strptime("1A", "%y") == {:error, {:invalid_integer, [modifier: "%y"]}}
+      assert Datix.strptime("1A", "%y") ==
+               {:error, %ParseError{reason: :invalid_integer, modifier: "%y"}}
     end
 
     # %Y - Year
@@ -267,7 +285,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %z" do
-      assert Datix.strptime("foo", "%z") == {:error, {:invalid_integer, [modifier: "%z"]}}
+      assert Datix.strptime("foo", "%z") ==
+               {:error, %ParseError{reason: :invalid_integer, modifier: "%z"}}
     end
 
     # %Z - Time zone abbreviation
@@ -278,7 +297,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid value for modifier %Z" do
-      assert Datix.strptime("foo", "%Z") == {:error, {:invalid_string, [modifier: "%Z"]}}
+      assert Datix.strptime("foo", "%Z") ==
+               {:error, %ParseError{reason: :invalid_string, modifier: "%Z"}}
     end
 
     # %% - Literal "%" character
@@ -321,49 +341,53 @@ defmodule DatixTest do
 
     test "returns error tuple for conflicting days of week" do
       assert Datix.strptime("Wednesday, Fri", "%A, %a") ==
-               {:error, {:conflict, [expected: 3, got: 5, modifier: "%a"]}}
+               {:error, %ParseError{reason: {:conflict, 3, 5}, modifier: "%a"}}
     end
 
     test "returns error tuple for conflicting days" do
       assert Datix.strptime("02, 03", "%d, %d") ==
-               {:error, {:conflict, [expected: 2, got: 3, modifier: "%d"]}}
+               {:error, %ParseError{reason: {:conflict, 2, 3}, modifier: "%d"}}
     end
 
     test "returns error tuple for conflicting am/pm" do
       assert Datix.strptime("AM, pm", "%p, %P") ==
-               {:error, {:conflict, [expected: :am, got: :pm, modifier: "%P"]}}
+               {:error, %ParseError{reason: {:conflict, :am, :pm}, modifier: "%P"}}
     end
   end
 
   describe "strptime!/3" do
-    test "raisee an error for an invalid sting" do
-      msg = "invalid string for %a"
+    test "returns the parsed result if valid" do
+      assert Datix.strptime!("15:30:00", "%H:%M:%S") == %{hour: 15, minute: 30, second: 0}
+    end
 
-      assert_raise ArgumentError, msg, fn ->
+    test "raises an error tuple for an unknown option" do
+      assert_raise OptionError, "unknown option :foo", fn ->
+        Datix.strptime!("", "", foo: :bar)
+      end
+    end
+
+    test "raises an error for an invalid sting" do
+      assert_raise ParseError, "invalid string for %a", fn ->
         Datix.strptime!("Xan", "%a")
       end
     end
 
-    test "raisee an error for an invalid integer" do
-      msg = "invalid integer for %d"
-
-      assert_raise ArgumentError, msg, fn ->
+    test "raises an error for an invalid integer" do
+      assert_raise ParseError, "invalid integer for %d", fn ->
         Datix.strptime!("1X", "%d")
       end
     end
 
-    test "raisee an error for an invalid input" do
-      msg = "invalid input"
-
-      assert_raise ArgumentError, msg, fn ->
+    test "raises an error for an invalid input" do
+      assert_raise ParseError, "invalid input", fn ->
         Datix.strptime!("10a", "%d")
       end
     end
 
-    test "raisee an error for a parse error" do
-      msg = ~s|parse error: expected "b", got "a"|
+    test "raises an error for a parse error" do
+      msg = ~s|expected exact string "b", got: "a"|
 
-      assert_raise ArgumentError, msg, fn ->
+      assert_raise ParseError, msg, fn ->
         Datix.strptime!("a", "b")
       end
     end
@@ -371,7 +395,7 @@ defmodule DatixTest do
     test "raises an error for conflicting data" do
       msg = "expected 3, got 5 for %a"
 
-      assert_raise ArgumentError, msg, fn ->
+      assert_raise ParseError, msg, fn ->
         Datix.strptime!("Wednesday, Fri", "%A, %a")
       end
     end
@@ -387,7 +411,8 @@ defmodule DatixTest do
     end
 
     test "returns error tuple for invalid modifier" do
-      assert {:error, {:invalid_modifier, [modifier: "%l"]}} = Datix.compile("%l")
+      assert {:error, %Datix.FormatStringError{reason: {:invalid_modifier, "%l"}}} =
+               Datix.compile("%l")
     end
 
     modifiers_with_defaults = [
@@ -468,7 +493,7 @@ defmodule DatixTest do
     end
 
     test "raises on invalid input" do
-      assert_raise ArgumentError, "invalid format: %l", fn ->
+      assert_raise Datix.FormatStringError, ~r/invalid modifier: %l/, fn ->
         Datix.compile!("%l")
       end
     end


### PR DESCRIPTION
I'm a big fan of [this classic blog post](https://michal.muskala.eu/post/error-handling-in-elixir-libraries/). I think there are many benefits from returning **exception structs** when returning `{:error, _}` tuples:

1. They can be raised with `raise/1`
2. They're easier to pattern-match on
3. They can be documented very well

See an example of PR similar to this here: https://github.com/elixir-gettext/expo/pull/74

This is a breaking change which would require releasing 0.3.0, but I personally think it's worth it. If we decided to change other APIs as we mentioned in https://github.com/hrzndhrn/datix/issues/7, we could bundle the breaking changes together and release the version 🙃 

What do you folks think @NickNeck? cc @wojtekmach